### PR TITLE
Adds a stub "icmp" test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Temporary Build Files
 _cache
 cnf-tests/bin

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Overview
 
-This repo contains example kustomize configs used to installed openshift features required for CNF workloads and a e2e functional test suite used to verify cnf related features.
+This repo contains example kustomize configs used to installed OpenShift features required for CNF workloads and an e2e functional test suite used to verify cnf related features.
 
 ## Contributing kustomize configs
 
-All kustomize configs should be entirely declarative in nature. This means no bash plugin modules performing imparative tasks. Features should be installed simply by posting manifests to the cluster. After posting manifests, determining when the cluster has converged on those manifests successully should be observable.
+All kustomize configs should be entirely declarative in nature. This means no bash plugin modules performing imperative tasks. Features should be installed simply by posting manifests to the cluster. After posting manifests, determining when the cluster has converged on those manifests successfully should be observable.
 
 ## Usage
 
@@ -27,13 +27,13 @@ The current default values is `"sctp performace"`
 
 ##### FEATURES_ENVIRONMENT
 
-i.e. `FEATURES_ENVIRONMENT=demo` determines the kustomization layer that will be used to deploy the choosen features.
+i.e. `FEATURES_ENVIRONMENT=demo` determines the kustomization layer that will be used to deploy the chosen features.
 
 The current default values is `e2e-gcp`
 
 ### Deployment
 
-For each feature choosen via `FEATURES` we expect to have a layer either in [feature-configs/deploy](feature-configs/deploy) or in [feature-configs/$FEATURES_ENVIRONMENT](feature-configs/demo).
+For each feature chosen via `FEATURES` we expect to have a layer either in [feature-configs/deploy](feature-configs/deploy) or in [feature-configs/$FEATURES_ENVIRONMENT](feature-configs/demo).
 
 - run `FEATURES_ENVIRONMENT=demo make feature-deploy`.  
   This will try to apply all manifests in a loop until all deployments succeeded, or until it runs into a timeout.

--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.13 AS builder
-WORKDIR /go/src/github.com/openshift-kni/cnf-features-deploy
+WORKDIR /go/src/github.com/rgoulding/cnf-features-deploy
 COPY . .
 RUN make test-bin
 RUN git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt
@@ -7,7 +7,7 @@ RUN git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt
 FROM quay.io/openshift/origin-oc-rpms:4.5 AS oc
 
 FROM golang:1.13 AS builder-stresser
-ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_NAME=github.com/rgoulding/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
 ENV TESTER_PATH=$PKG_PATH/cnf-tests/testbinaries/stresser
 
@@ -19,7 +19,7 @@ WORKDIR $TESTER_PATH
 RUN go build -mod=vendor -o /stresser
 
 FROM golang:1.13 AS builder-sctptester
-ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_NAME=github.com/rgoulding/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
 ENV TESTER_PATH=$PKG_PATH/cnf-tests/testbinaries/sctptester
 
@@ -40,13 +40,13 @@ COPY --from=builder-stresser /stresser /usr/bin/stresser
 COPY --from=builder-sctptester /sctptest /usr/bin/sctptest
 
 COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/configsuite /usr/bin/configsuite
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/validationsuite /usr/bin/validationsuite
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/test-run.sh /usr/bin/test-run.sh
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/mirror /usr/bin/mirror
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/images.json /usr/local/etc/cnf
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests-sha.txt /usr/local/etc/cnf
+COPY --from=builder /go/src/github.com/rgoulding/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
+COPY --from=builder /go/src/github.com/rgoulding/cnf-features-deploy/cnf-tests/bin/configsuite /usr/bin/configsuite
+COPY --from=builder /go/src/github.com/rgoulding/cnf-features-deploy/cnf-tests/bin/validationsuite /usr/bin/validationsuite
+COPY --from=builder /go/src/github.com/rgoulding/cnf-features-deploy/cnf-tests/test-run.sh /usr/bin/test-run.sh
+COPY --from=builder /go/src/github.com/rgoulding/cnf-features-deploy/cnf-tests/bin/mirror /usr/bin/mirror
+COPY --from=builder /go/src/github.com/rgoulding/cnf-features-deploy/cnf-tests/images.json /usr/local/etc/cnf
+COPY --from=builder /go/src/github.com/rgoulding/cnf-features-deploy/cnf-tests/bin/cnftests-sha.txt /usr/local/etc/cnf
 
 ENV SUITES_PATH=/usr/bin/
 

--- a/cnf-tests/images.json
+++ b/cnf-tests/images.json
@@ -1,10 +1,10 @@
 [
     {
-        "registry": "quay.io/openshift-kni/",
+        "registry": "quay.io/rgoulding/",
         "image": "cnf-tests:4.5"
     },
     {
-        "registry": "quay.io/openshift-kni/",
+        "registry": "quay.io/rgoulding/",
         "image": "dpdk:4.5"
     }
 ]

--- a/functests/icmp/icmp.go
+++ b/functests/icmp/icmp.go
@@ -1,0 +1,45 @@
+<<<<<<< HEAD
+/*
+Package icmp is not implemented, and purely a demo stub!  This stub test suite shows how one might run a custom test in
+the "cnf-features-deploy" code base.
+
+To Build:
+docker build --no-cache -f cnf-tests/Dockerfile -t quay.io/rgoulding/cnf-tests .
+
+To Push the image to quay.io:
+docker push quay.io/rgoulding/cnf-tests
+
+To Run:
+docker pull quay.io/rgoulding/cnf-tests
+docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig quay.io/rgoulding/cnf-tests /usr/bin/cnftests -ginkgo.v -ginkgo.focus="icmp"
+*/
+
+package icmp
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/execute"
+)
+
+var _ = Describe("icmp", func() {
+
+	execute.BeforeAll(func() {
+
+	})
+
+	Context("Validate ICMP to Google", func() {
+		It("Should forward and receive packets", func() {
+			// should always fail.
+			Expect("nil").ToNot(BeNil())
+		})
+	})
+
+	var _ = Describe("Test ICMP", func() {
+
+	})
+})
+=======
+package icmp
+
+>>>>>>> 67c9d2b... Test

--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/dpdk" // this is needed otherwise the dpdk test won't be executed
+	_ "github.com/openshift-kni/cnf-features-deploy/functests/icmp"
 	"github.com/openshift-kni/cnf-features-deploy/functests/ptp"
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/ptp" // this is needed otherwise the ptp test won't be executed
 	"github.com/openshift-kni/cnf-features-deploy/functests/sctp"
@@ -100,6 +101,13 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	_, err = testclient.Client.Namespaces().Create(ns)
+
+	ns = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespaces.IcmpTest,
+		},
+	}
+
 	Expect(err).ToNot(HaveOccurred())
 })
 
@@ -120,6 +128,7 @@ var _ = AfterSuite(func() {
 		namespaces.DpdkTest,
 		sctp.TestNamespace,
 		sriovNamespaces.Test,
+		namespaces.IcmpTest,
 	}
 
 	for _, n := range nn {

--- a/functests/utils/client/clients.go
+++ b/functests/utils/client/clients.go
@@ -63,7 +63,7 @@ func New(kubeconfig string) *ClientSet {
 		config, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		glog.Infof("Failed to init kubernetes client, please check the $KUBECONFIG environment variable")
+		glog.Infof("Failed to init kubernetes client, please check the $KUBECONFIG environment variable: %s", err)
 		return nil
 	}
 

--- a/functests/utils/namespaces/namespaces.go
+++ b/functests/utils/namespaces/namespaces.go
@@ -17,6 +17,7 @@ import (
 
 // DpdkTest is the namespace of dpdk test suite
 var DpdkTest string
+const IcmpTest = "icmp-testing"
 
 func init() {
 	DpdkTest = os.Getenv("DPDK_TEST_NAMESPACE")


### PR DESCRIPTION
"cnf-features-deploy" is an officially vended Red Hat product.
There are several mechanisms to deliver a test suite into
cnf-features-deploy, including directly adding test code to the
existing code base.  This change includes a forked version, which
adds in an "icmp" test suite.  This test suite is designed to always
pass, and just demonstrates the entrypoint into the test harness.

Additionally, this change includes code to build a forked docker
image for the test suite, quay.io/rgoulding/cnf-tests.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>